### PR TITLE
fix: 控制面板中各项分页数据不准确

### DIFF
--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -422,10 +422,10 @@ func AddV1Route(app iris.Party) {
 
 	session.Install(v1Party)
 	mfa.Install(v1Party)
-	authParty := v1Party.Party("")
 	v1Party.Use(langHandler())
 	v1Party.Use(pageHandler())
-
+	
+	authParty := v1Party.Party("")
 	authParty.Use(WarpedJwtHandler())
 	authParty.Use(authHandler())
 	authParty.Use(resourceExtractHandler())


### PR DESCRIPTION
#### 修复控制面板中分页数据不准确的问题
    由于 `authParty := v1Party.Party("")` 定义在 `v1Party.Use(pageHandler())`之前，导致 `authParty` 所有路由未使用到 
 `pageHandler` 中间件，相关分页数据不准确。